### PR TITLE
Fix error in game saving code

### DIFF
--- a/Client/WebQuake/Host.js
+++ b/Client/WebQuake/Host.js
@@ -664,7 +664,7 @@ Host.Savegame_f = function()
 		if ((type & 0x8000) === 0)
 			continue;
 		type &= 0x7fff;
-		if ((type !== PR.etype.ev_string) && (type !== PR.etype.ev_float) && (type !== PR.etype.entity))
+		if ((type !== PR.etype.ev_string) && (type !== PR.etype.ev_float) && (type !== PR.etype.ev_entity))
 			continue;
 		f[f.length] = '"' + PR.GetString(def.name) + '" "' + PR.UglyValueString(type, PR.globals, def.ofs) + '"\n';
 	}


### PR DESCRIPTION
This error prevents values of type ev_entity from being saved.

I saw this manifest as a reproducible crash with Scourge of Armagon, caused by the persistent-bullet-holes code:
1. Start a new game of Scourge of Armagon
2. Walk up to a wall and shoot the shotgun at it more than 10 times (when the bullet holes start disappearing)
3. Save the game
4. Load the game
5. Shoot the shotgun again -> crash with "bullethole == nullentity"